### PR TITLE
Load all reference images at once

### DIFF
--- a/src/components/ProjectCard/ProjectCard.jsx
+++ b/src/components/ProjectCard/ProjectCard.jsx
@@ -1,4 +1,4 @@
-const ProjectCard = ({project}) => {
+const ProjectCard = ({project, allImagesLoaded}) => {
   const {imageUrl, title} = project;
   return (
     <div className='project-item'>
@@ -6,6 +6,8 @@ const ProjectCard = ({project}) => {
         className="background-image"
         style={{
           backgroundImage: `url(${imageUrl})`,
+          opacity: allImagesLoaded ? 1 : 0,
+          transition: 'opacity 300ms ease'
         }}
       />
       <div className="project-body-container">

--- a/src/components/ProjectsList/ProjectsList.jsx
+++ b/src/components/ProjectsList/ProjectsList.jsx
@@ -30,8 +30,18 @@ const ProjectsList = ({projects}) => {
       isCancelled = true
     }
   }, [projects])
+  if (!allImagesLoaded) {
+    return (
+      <div className="projects-loader" aria-label="Loading projects" role="status">
+        <span className="projects-loader__dot" />
+        <span className="projects-loader__dot" />
+        <span className="projects-loader__dot" />
+      </div>
+    )
+  }
+
   return (
-    <div className={`projects-container ${allImagesLoaded ? 'is-loaded' : ''}`} style={{ visibility: allImagesLoaded ? 'visible' : 'hidden' }}>
+    <div className={`projects-container ${allImagesLoaded ? 'is-loaded' : ''}`}>
       {projects.map((project) => (
         <ProjectCard key={project.id} project={project} allImagesLoaded={allImagesLoaded} />
       ))}

--- a/src/components/ProjectsList/ProjectsList.jsx
+++ b/src/components/ProjectsList/ProjectsList.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import './ProjectsList.scss'
 import ProjectCard from '../ProjectCard/ProjectCard'
 
 const ProjectsList = ({projects}) => {
@@ -30,7 +31,7 @@ const ProjectsList = ({projects}) => {
     }
   }, [projects])
   return (
-    <div className="projects-container" style={{ visibility: allImagesLoaded ? 'visible' : 'hidden' }}>
+    <div className={`projects-container ${allImagesLoaded ? 'is-loaded' : ''}`} style={{ visibility: allImagesLoaded ? 'visible' : 'hidden' }}>
       {projects.map((project) => (
         <ProjectCard key={project.id} project={project} />
       ))}

--- a/src/components/ProjectsList/ProjectsList.jsx
+++ b/src/components/ProjectsList/ProjectsList.jsx
@@ -1,6 +1,39 @@
+import { useEffect, useState } from 'react'
 import ProjectCard from '../ProjectCard/ProjectCard'
 
 const ProjectsList = ({projects}) => {
+  const [allImagesLoaded, setAllImagesLoaded] = useState(false)
+
+  useEffect(() => {
+    const imageUrls = (projects || []).map((p) => p.imageUrl).filter(Boolean)
+
+    if (imageUrls.length === 0) {
+      setAllImagesLoaded(true)
+      return
+    }
+
+    let isCancelled = false
+
+    const preloadPromises = imageUrls.map((src) => new Promise((resolve) => {
+      const img = new Image()
+      img.onload = () => resolve()
+      img.onerror = () => resolve()
+      img.src = src
+    }))
+
+    Promise.all(preloadPromises).then(() => {
+      if (!isCancelled) setAllImagesLoaded(true)
+    })
+
+    return () => {
+      isCancelled = true
+    }
+  }, [projects])
+
+  if (!allImagesLoaded) {
+    return null
+  }
+
   return (
     <div className="projects-container">
       {projects.map((project) => (

--- a/src/components/ProjectsList/ProjectsList.jsx
+++ b/src/components/ProjectsList/ProjectsList.jsx
@@ -29,13 +29,8 @@ const ProjectsList = ({projects}) => {
       isCancelled = true
     }
   }, [projects])
-
-  if (!allImagesLoaded) {
-    return null
-  }
-
   return (
-    <div className="projects-container">
+    <div className="projects-container" style={{ visibility: allImagesLoaded ? 'visible' : 'hidden' }}>
       {projects.map((project) => (
         <ProjectCard key={project.id} project={project} />
       ))}

--- a/src/components/ProjectsList/ProjectsList.jsx
+++ b/src/components/ProjectsList/ProjectsList.jsx
@@ -33,7 +33,7 @@ const ProjectsList = ({projects}) => {
   return (
     <div className={`projects-container ${allImagesLoaded ? 'is-loaded' : ''}`} style={{ visibility: allImagesLoaded ? 'visible' : 'hidden' }}>
       {projects.map((project) => (
-        <ProjectCard key={project.id} project={project} />
+        <ProjectCard key={project.id} project={project} allImagesLoaded={allImagesLoaded} />
       ))}
     </div>
   )

--- a/src/components/ProjectsList/ProjectsList.scss
+++ b/src/components/ProjectsList/ProjectsList.scss
@@ -1,0 +1,9 @@
+.projects-container {
+  opacity: 0;
+  transition: opacity 300ms ease;
+}
+
+.projects-container.is-loaded {
+  opacity: 1;
+}
+

--- a/src/components/ProjectsList/ProjectsList.scss
+++ b/src/components/ProjectsList/ProjectsList.scss
@@ -7,3 +7,27 @@
   opacity: 1;
 }
 
+.projects-loader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 200px;
+}
+
+.projects-loader__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #999;
+  animation: projects-bounce 1s infinite ease-in-out;
+}
+
+.projects-loader__dot:nth-child(2) { animation-delay: 0.15s; }
+.projects-loader__dot:nth-child(3) { animation-delay: 0.3s; }
+
+@keyframes projects-bounce {
+  0%, 80%, 100% { transform: scale(0.6); opacity: 0.6; }
+  40% { transform: scale(1); opacity: 1; }
+}
+

--- a/src/routes/Home/Home.jsx
+++ b/src/routes/Home/Home.jsx
@@ -1,12 +1,12 @@
 import ProjectsList from '../../components/ProjectsList/ProjectsList'
-import { projects } from '../../projects-data'
+import { PROJECTS_DATA } from '../../projects-data'
 import './Home.scss'
 
 const Home = () => {
 
   return (
     <div>
-      <ProjectsList projects={projects}/>
+      <ProjectsList projects={PROJECTS_DATA}/>
     </div>
   )
 }


### PR DESCRIPTION
Preload project images in `ProjectsList` to ensure they appear simultaneously instead of loading one by one.

---
<a href="https://cursor.com/background-agent?bcId=bc-312c8ca1-6543-4e6d-8fb9-ee2708c29cc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-312c8ca1-6543-4e6d-8fb9-ee2708c29cc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

